### PR TITLE
fix: register before List(); test: check for dropped events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,11 @@ lint: ## Runs go fmt.
 
 .PHONY: test
 test: ## Runs go test.
-	@CGO_ENABLED=1 go test -race -v ./...
+	@CGO_ENABLED=1 GOTRACEBACK=all go test -race -v ./...
 
 .PHONY: test-ci
 test-ci:
-	@CGO_ENABLED=1 go test -coverprofile=cover.out -failfast -race -count 10 -shuffle on -v ./...
+	@CGO_ENABLED=1 GOTRACEBACK=all go test -coverprofile=cover.out -failfast -count 10 -race -shuffle on -v ./...
 
 .PHONY: bench
 bench: ## Runs go test with benchmarks.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Writing Kubernetes controllers is easier when you can:
 - [X] Indexer -- indexing an existing collection for quicker lookup.
 - [X] Fetch -- fetching from a collection and tracking dependencies.
 - [X] UnregisterHandler -- for listening temporarily
-- [ ] Filtering -- Filtering collections and on fetch.
+- [X] Filtering -- Filtering collections on fetch.
   - [ ] Filters / Indexers for StaticCollection
 - [ ] CollectionOption -- tweaking how collectors work in various ways.
   - [X] WithName Collection names (very needed for debugging)

--- a/pkg/core.go
+++ b/pkg/core.go
@@ -113,10 +113,11 @@ type Singleton[T any] interface {
 
 // collectionShared contains metadata and fields common to controllers.
 type collectionShared struct {
-	uid          uint64
-	name         string
-	stop         <-chan struct{}
-	pollInterval *time.Duration
+	uid                 uint64
+	name                string
+	stop                <-chan struct{}
+	pollInterval        *time.Duration
+	wantSpuriousUpdates bool
 }
 
 //nolint:unused // implementing interface

--- a/pkg/derived_collection_test.go
+++ b/pkg/derived_collection_test.go
@@ -113,8 +113,8 @@ func TestDerivedCollectionInitialState(t *testing.T) {
 			Spec: corev1.ServiceSpec{Selector: map[string]string{"app": "foo"}},
 		},
 	)
-	pods := krtlite.NewTypedClientInformer[*corev1.Pod](ctx, c.CoreV1().Pods("namespace"))
-	services := krtlite.NewTypedClientInformer[*corev1.Service](ctx, c.CoreV1().Services("namespace"))
+	pods := krtlite.NewTypedClientInformer[*corev1.Pod](ctx, c.CoreV1().Pods("namespace"), krtlite.WithName("Pods"))
+	services := krtlite.NewTypedClientInformer[*corev1.Service](ctx, c.CoreV1().Services("namespace"), krtlite.WithName("Services"))
 
 	// assert that collections are equal immediately after waiting for sync.
 	SimplePods := SimplePodCollection(pods)

--- a/pkg/derived_collection_test.go
+++ b/pkg/derived_collection_test.go
@@ -8,7 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
-	"log/slog"
 	"slices"
 	"testing"
 )
@@ -434,7 +433,6 @@ func TestDerivedCollectionMultipleFetch(t *testing.T) {
 		}
 
 		slices.Sort(names)
-		slog.Debug("called map handler", "Configs", names, "foos", foos, "bars", bars)
 		return &Result{
 			Named:   NewNamed(i),
 			Configs: names,

--- a/pkg/fifo/queue.go
+++ b/pkg/fifo/queue.go
@@ -15,6 +15,7 @@ func NewQueue[T any](size int) *Queue[T] {
 		in:  make(chan T),
 		out: make(chan T),
 
+		// newRingBuf is not thread-safe -- this is fine, because we only use it from a single goroutine.
 		queue:   newRingBuf[T](size),
 		running: false,
 	}

--- a/pkg/informer.go
+++ b/pkg/informer.go
@@ -176,35 +176,6 @@ func (i *informer[T]) RegisterBatched(f func(ev []Event[T]), runExistingState bo
 
 func (i *informer[T]) WaitUntilSynced(stop <-chan struct{}) (result bool) {
 	return i.syncer.WaitUntilSynced(stop)
-	//if i.syncer.HasSynced() {
-	//	return true
-	//}
-	//
-	//t0 := time.Now()
-	//
-	//defer func() {
-	//	i.logger().Info("informer synced", "waitTime", time.Since(t0))
-	//}()
-	//
-	//for {
-	//	select {
-	//	case <-stop:
-	//		return false
-	//	default:
-	//	}
-	//	if i.syncer.HasSynced() {
-	//		return true
-	//	}
-	//
-	//	// sleep for 1 second, but return if the stop chan is closed.
-	//	t := time.NewTimer(*i.pollInterval)
-	//	select {
-	//	case <-stop:
-	//		return false
-	//	case <-t.C:
-	//	}
-	//	i.logger().Info("informer waiting for sync", "waitTime", time.Since(t0))
-	//}
 }
 
 func (i *informer[T]) HasSynced() bool {

--- a/pkg/options.go
+++ b/pkg/options.go
@@ -22,3 +22,11 @@ func WithPollInterval(interval time.Duration) CollectionOption {
 		m.pollInterval = &interval
 	}
 }
+
+// WithSpuriousUpdates configures collections from Map and FlatMap to send update events downstream even if old and new
+// objects are identical. Has no effect for other collections.
+func WithSpuriousUpdates() CollectionOption {
+	return func(m *collectionShared) {
+		m.wantSpuriousUpdates = true
+	}
+}

--- a/pkg/scale_test.go
+++ b/pkg/scale_test.go
@@ -1,0 +1,137 @@
+package pkg_test
+
+import (
+	"context"
+	"fmt"
+	krtlite "github.com/kalexmills/krt-lite/pkg"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"log/slog"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+	"time"
+)
+
+// TestDetectDroppedEvents ensures that events are not dropped at larger scales.
+func TestDetectDroppedEvents(t *testing.T) {
+
+	const (
+		N       = 100
+		K       = 100 // K cannot be higher than watch.DefaultChanSize, which can't be set with the race detector enabled
+		timeout = 5 * time.Second
+	)
+
+	oldLevel := slog.SetLogLoggerLevel(slog.LevelWarn)
+	defer slog.SetLogLoggerLevel(oldLevel)
+
+	ctx, cancel := context.WithTimeout(t.Context(), timeout)
+	defer cancel()
+
+	c := fake.NewFakeClient()
+
+	var initialPods []*corev1.Pod
+	for i := 0; i < K; i++ {
+		initialPods = append(initialPods, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("pod-%d", i),
+				Namespace: fmt.Sprintf("ns-%d", i%2),
+				Labels: map[string]string{
+					"app": fmt.Sprintf("app-%d", i%25),
+				},
+			},
+			Spec: corev1.PodSpec{
+				ServiceAccountName: "fake-sa",
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				PodIP: GetIP(),
+			},
+		})
+	}
+
+	var initialServices []*corev1.Service
+	for i := 0; i < 50; i++ {
+		initialServices = append(initialServices, &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("pod-%d", i),
+				Namespace: fmt.Sprintf("ns-%d", i%2),
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"app": fmt.Sprintf("app-%d", i%25),
+				},
+			},
+		})
+	}
+
+	events := make(chan string, K)
+
+	Pods := krtlite.NewInformer[*corev1.Pod, corev1.PodList](ctx, c, krtlite.WithName("Pods"))
+	Services := krtlite.NewInformer[*corev1.Service, corev1.ServiceList](ctx, c, krtlite.WithName("Services"))
+	ServicesByNamespace := krtlite.NewNamespaceIndex(Services)
+
+	Workloads := krtlite.Map(Pods, func(ktx krtlite.Context, p *corev1.Pod) *Workload {
+		if p.Status.PodIP == "" {
+			return nil
+		}
+
+		services := krtlite.Fetch(ktx, Services, krtlite.MatchIndex(ServicesByNamespace, p.Namespace),
+			krtlite.MatchSelectsLabels(p.Labels, krtlite.LabelSelectorExtractor))
+
+		result := &Workload{
+			Named: NewNamed(p),
+			IP:    p.Status.PodIP,
+		}
+
+		for _, service := range services {
+			result.ServiceNames = append(result.ServiceNames, service.Name)
+		}
+		return result
+	}, krtlite.WithName("Workloads"), krtlite.WithSpuriousUpdates())
+
+	reg := Workloads.Register(func(e krtlite.Event[Workload]) {
+		events <- fmt.Sprintf("%s-%s", e.Latest().Name, e.Event)
+	})
+
+	reg.WaitUntilSynced(ctx.Done())
+
+	for _, pod := range initialPods {
+		_ = c.Create(ctx, pod)
+	}
+
+	for _, s := range initialServices {
+		_ = c.Create(ctx, s)
+	}
+
+	count := 0
+	for n := 0; n < N; n++ {
+		for i := 0; i < K; i++ { // send K updates
+			_ = c.Update(ctx, &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("pod-%d", i),
+					Namespace: fmt.Sprintf("ns-%d", i%2),
+					Labels: map[string]string{
+						"app": fmt.Sprintf("app-%d", i%25),
+					},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "fake-sa",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					PodIP: GetIP(),
+				},
+			})
+		}
+		// drain K updates from the queue, if fewer than exactly 1000 updates were sent, this will force a deadlock
+		for i := 0; i < K; i++ {
+			select {
+			case <-events:
+				count++
+			case <-ctx.Done():
+				// panic to force a stack trace. If you do not see one, run go test with GOTRACEBACK=all.
+				panic(fmt.Sprintf("system deadlocked after %s: received %d events; sent %d", timeout, count, (n+1)*1000))
+			}
+		}
+	}
+}

--- a/pkg/scale_test.go
+++ b/pkg/scale_test.go
@@ -14,7 +14,6 @@ import (
 
 // TestDetectDroppedEvents ensures that events are not dropped at larger scales.
 func TestDetectDroppedEvents(t *testing.T) {
-
 	const (
 		N       = 100
 		K       = 100 // K cannot be higher than watch.DefaultChanSize, which can't be set with the race detector enabled

--- a/pkg/singleton.go
+++ b/pkg/singleton.go
@@ -1,7 +1,6 @@
 package pkg
 
 import (
-	"k8s.io/client-go/tools/cache"
 	"sync"
 	"sync/atomic"
 )
@@ -18,8 +17,11 @@ func NewSingleton[T any](initial *T, startSynced bool, opts ...CollectionOption)
 
 type singleton[T any] struct {
 	collectionShared
-	val     atomic.Pointer[T]
-	synced  atomic.Bool
+	val atomic.Pointer[T]
+
+	closeSynced *sync.Once
+	syncedCh    chan struct{}
+
 	currKey string
 
 	mut      *sync.RWMutex
@@ -30,7 +32,8 @@ func newSingleton[T any](opts []CollectionOption) *singleton[T] {
 	return &singleton[T]{
 		collectionShared: newCollectionShared(opts),
 		val:              atomic.Pointer[T]{},
-		synced:           atomic.Bool{},
+		syncedCh:         make(chan struct{}),
+		closeSynced:      &sync.Once{},
 		mut:              new(sync.RWMutex),
 		handlers:         make(map[*func(o []Event[T])]struct{}),
 	}
@@ -87,11 +90,17 @@ func (s *singleton[T]) unregister(f *func(o []Event[T])) func() {
 }
 
 func (s *singleton[T]) WaitUntilSynced(stop <-chan struct{}) bool {
-	return cache.WaitForCacheSync(stop, s.HasSynced) // TODO: remove WaitForCacheSync
+	<-s.syncedCh
+	return true
 }
 
 func (s *singleton[T]) HasSynced() bool {
-	return s.synced.Load()
+	select {
+	case <-s.syncedCh:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *singleton[T]) Get() *T {
@@ -133,7 +142,9 @@ func (s *singleton[T]) Set(now *T) {
 }
 
 func (s *singleton[T]) MarkSynced() {
-	s.synced.Store(true)
+	s.closeSynced.Do(func() {
+		close(s.syncedCh)
+	})
 }
 
 type singletonRegistration struct {

--- a/pkg/syncer.go
+++ b/pkg/syncer.go
@@ -122,10 +122,7 @@ func (s *pollingSyncer) WaitUntilSynced(stop <-chan struct{}) bool {
 			return true, nil
 		},
 	)
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 func (s *pollingSyncer) HasSynced() bool {


### PR DESCRIPTION
- fix test failure: register must happen before List() in Fetch.
- test: check for dropped events.
- feat: remove cache.WaitUntilCacheSync everywhere -- so users can control polling more carefully.