### PR TITLE
Fix: receiving tasks from closed channel will panic.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ lint: ## Runs go fmt.
 
 .PHONY: test
 test: ## Runs go test.
-	@CGO_ENABLED=1 GOTRACEBACK=all go test -race -v ./...
+	@CGO_ENABLED=1 GOTRACEBACK=all go test -failfast -race -v ./...
 
 .PHONY: test-ci
 test-ci: ## Runs go test 10 times

--- a/core.go
+++ b/core.go
@@ -167,7 +167,6 @@ func (c collectionShared) getName() string { //nolint:unused // implementing int
 	return c.name
 }
 
-//nolint:unused // implementing interface
 func (c collectionShared) getUID() uint64 { //nolint:unused // implementing interface
 	return c.uid
 }

--- a/derived_collection.go
+++ b/derived_collection.go
@@ -249,7 +249,11 @@ func (c *derivedCollection[I, O]) processTaskQueue() {
 			c.logger().Info("stopping task queue")
 			return
 		case t := <-c.taskQueue.Out():
-			t()
+			if t != nil {
+				t()
+			} else {
+				c.logger().Warn("task queue received a nil task")
+			}
 		}
 	}
 }

--- a/derived_collection.go
+++ b/derived_collection.go
@@ -248,12 +248,12 @@ func (c *derivedCollection[I, O]) processTaskQueue() {
 		case <-c.stop:
 			c.logger().Info("stopping task queue")
 			return
-		case t := <-c.taskQueue.Out():
-			if t != nil {
-				t()
-			} else {
-				c.logger().Warn("task queue received a nil task")
+		case t, ok := <-c.taskQueue.Out():
+			if !ok {
+				c.logger().Info("task queue closed")
+				return
 			}
+			t()
 		}
 	}
 }
@@ -601,6 +601,7 @@ func (p *registrationHandler[T]) run() {
 		select {
 		case fromQueue, ok := <-p.queue.Out():
 			if !ok {
+				p.parent.logger().Debug("stopping registration handler; queue closed")
 				return
 			}
 			if fromQueue.initialEventsSent {

--- a/leak_test.go
+++ b/leak_test.go
@@ -1,4 +1,4 @@
-package krtlite
+package krtlite_test
 
 import (
 	"istio.io/istio/tests/util/leak"


### PR DESCRIPTION
After cleaning up goroutine leaks, an issue with receiving tasks from a closed task queue was surfaced. This addresses the bug.