### PR TITLE
Dynamic Informer; Joined Collections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test: ## Runs go test.
 
 .PHONY: test-ci
 test-ci: ## Runs go test 10 times
-	@CGO_ENABLED=1 GOTRACEBACK=all go test -coverprofile=cover.out -failfast -count 10 -race -shuffle on -v ./...
+	@CGO_ENABLED=1 GOTRACEBACK=all go test -coverprofile=cover.out -count 10 -race -shuffle on -v ./...
 
 .PHONY: test-isolate-leak
 test-isolate-leak: ## Runs each test individually to detect leak failures.

--- a/core_test.go
+++ b/core_test.go
@@ -1,0 +1,56 @@
+package krtlite
+
+import (
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+type keyerImpl string
+
+func (k keyerImpl) Key() string {
+	return string(k)
+}
+
+func TestGetKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		arg      any
+	}{
+		{
+			name:     "string",
+			expected: "foo",
+			arg:      "foo",
+		},
+		{
+			name:     "configmap",
+			expected: "ns/a",
+			arg: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "a"},
+			},
+		},
+		{
+			name:     "node",
+			expected: "node-name",
+			arg: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-name"},
+			},
+		},
+		{
+			name:     "Keyer",
+			expected: "fromKeyer",
+			arg:      keyerImpl("fromKeyer"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				actual := GetKey(tt.arg)
+				assert.Equal(t, tt.expected, actual)
+			})
+		})
+	}
+}

--- a/fetch.go
+++ b/fetch.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Context is used to track dependencies between collections created via [FlatMap] and [Map], and collections accessed
-// via [Fetch]. See [Fetch] for details.
+// via [Fetch]. See [Fetch] for details. By convention it is spelled `ktx` to distinguish it from a [context.Context].
 type Context interface {
 	// registerDependency registers the provided dependency and syncer with the parent collection. Returns the dependency
 	// ID for the registered collection.

--- a/fetch.go
+++ b/fetch.go
@@ -22,6 +22,21 @@ type Context interface {
 	resetTrackingForCollection(collID uint64)
 }
 
+// FetchOne fetches a single item from another collection by key, tracking it as a dependency.
+//
+// Passing [MatchKeys] to FetchOne will panic.
+func FetchOne[T any](ktx Context, c Collection[T], key string, opts ...FetchOption) *T {
+	opts = append(opts, MatchKeys(key))
+	out := Fetch(ktx, c, opts...)
+	if len(out) > 1 {
+		panic("MatchKeys was passed to an invocation of FetchOne")
+	}
+	if len(out) == 1 {
+		return &out[0]
+	}
+	return nil
+}
+
 // Fetch calls List on the provided Collection, and can be used to subscribe Collections created by [Map] or [FlatMap]
 // to events from other Collections. Passing a non-nil [Context] to Fetch subscribes the collection to updates from
 // Collection c. Updates to any item returned from fetch will trigger recalculation of the handler that called Fetch.

--- a/informer_test.go
+++ b/informer_test.go
@@ -1,13 +1,21 @@
 package krtlite_test
 
 import (
+	"bytes"
 	"context"
 	krtlite "github.com/kalexmills/krt-lite"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	typedfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -21,49 +29,6 @@ type rig interface {
 	Create(ctx context.Context, t *corev1.ConfigMap) (*corev1.ConfigMap, error)
 	Update(ctx context.Context, t *corev1.ConfigMap) (*corev1.ConfigMap, error)
 	Delete(ctx context.Context, t *corev1.ConfigMap) error
-}
-
-type typedClientRig struct {
-	c *typedfake.Clientset
-}
-
-func (r typedClientRig) Collection(ctx context.Context, opts ...krtlite.CollectionOption) krtlite.Collection[*corev1.ConfigMap] {
-	return krtlite.NewTypedClientInformer[*corev1.ConfigMap](ctx, r.c.CoreV1().ConfigMaps(""), opts...)
-}
-
-func (r typedClientRig) Create(ctx context.Context, t *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	return r.c.CoreV1().ConfigMaps(t.Namespace).Create(ctx, t, metav1.CreateOptions{}) //nolint: wrapcheck
-}
-
-func (r typedClientRig) Update(ctx context.Context, t *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	return r.c.CoreV1().ConfigMaps(t.Namespace).Update(ctx, t, metav1.UpdateOptions{}) //nolint: wrapcheck
-}
-
-func (r typedClientRig) Delete(ctx context.Context, t *corev1.ConfigMap) error {
-	return r.c.CoreV1().ConfigMaps(t.Namespace).Delete(ctx, t.Name, metav1.DeleteOptions{}) //nolint: wrapcheck
-}
-
-type clientRig struct {
-	c client.WithWatch
-}
-
-func (r clientRig) Collection(ctx context.Context, opts ...krtlite.CollectionOption) krtlite.Collection[*corev1.ConfigMap] {
-	return krtlite.NewInformer[*corev1.ConfigMap, corev1.ConfigMapList](ctx, r.c, opts...)
-}
-
-func (r clientRig) Create(ctx context.Context, t *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	err := r.c.Create(ctx, t)
-	return t, err //nolint: wrapcheck
-}
-
-func (r clientRig) Update(ctx context.Context, t *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	err := r.c.Update(ctx, t)
-	return t, err //nolint: wrapcheck
-}
-
-func (r clientRig) Delete(ctx context.Context, t *corev1.ConfigMap) error {
-	err := r.c.Delete(ctx, t)
-	return err //nolint: wrapcheck
 }
 
 func TestInformer(t *testing.T) {
@@ -135,6 +100,131 @@ func TestInformer(t *testing.T) {
 			c: fake.NewFakeClient(),
 		})
 	})
+
+	t.Run("NewDynamicInformer", func(t *testing.T) {
+		doTest(t, &dynamicRig{
+			gvr:    schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},
+			client: dynamicfake.NewSimpleDynamicClient(scheme.Scheme),
+		})
+	})
+}
+
+type typedClientRig struct {
+	c *typedfake.Clientset
+}
+
+func (r typedClientRig) Collection(ctx context.Context, opts ...krtlite.CollectionOption) krtlite.Collection[*corev1.ConfigMap] {
+	return krtlite.NewTypedClientInformer[*corev1.ConfigMap](ctx, r.c.CoreV1().ConfigMaps(""), opts...)
+}
+
+func (r typedClientRig) Create(ctx context.Context, t *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return r.c.CoreV1().ConfigMaps(t.Namespace).Create(ctx, t, metav1.CreateOptions{}) //nolint: wrapcheck
+}
+
+func (r typedClientRig) Update(ctx context.Context, t *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return r.c.CoreV1().ConfigMaps(t.Namespace).Update(ctx, t, metav1.UpdateOptions{}) //nolint: wrapcheck
+}
+
+func (r typedClientRig) Delete(ctx context.Context, t *corev1.ConfigMap) error {
+	return r.c.CoreV1().ConfigMaps(t.Namespace).Delete(ctx, t.Name, metav1.DeleteOptions{}) //nolint: wrapcheck
+}
+
+type clientRig struct {
+	c client.WithWatch
+}
+
+func (r clientRig) Collection(ctx context.Context, opts ...krtlite.CollectionOption) krtlite.Collection[*corev1.ConfigMap] {
+	return krtlite.NewInformer[*corev1.ConfigMap, corev1.ConfigMapList](ctx, r.c, opts...)
+}
+
+func (r clientRig) Create(ctx context.Context, t *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	err := r.c.Create(ctx, t)
+	return t, err //nolint: wrapcheck
+}
+
+func (r clientRig) Update(ctx context.Context, t *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	err := r.c.Update(ctx, t)
+	return t, err //nolint: wrapcheck
+}
+
+func (r clientRig) Delete(ctx context.Context, t *corev1.ConfigMap) error {
+	err := r.c.Delete(ctx, t)
+	return err //nolint: wrapcheck
+}
+
+type dynamicRig struct {
+	gvr    schema.GroupVersionResource
+	client dynamic.Interface
+}
+
+func (d dynamicRig) Collection(ctx context.Context, opts ...krtlite.CollectionOption) krtlite.Collection[*corev1.ConfigMap] {
+	dynamicColl := krtlite.NewDynamicInformer(d.client, d.gvr)
+	return krtlite.Map(dynamicColl, func(ktx krtlite.Context, u *unstructured.Unstructured) **corev1.ConfigMap {
+		res := &corev1.ConfigMap{}
+		err := fromUnstructured(u, res)
+		if err != nil {
+			panic(err)
+		}
+		return &res
+	})
+}
+
+func toUnstructured[T runtime.Object](t T) (*unstructured.Unstructured, error) {
+	codec := scheme.Codecs.LegacyCodec(schema.GroupVersion{Group: corev1.GroupName, Version: "v1"})
+
+	buf := bytes.NewBuffer(make([]byte, 0, 1024))
+
+	if err := codec.Encode(t, buf); err != nil {
+		return nil, err
+	}
+
+	u := &unstructured.Unstructured{}
+
+	err := json.Unmarshal(buf.Bytes(), &u)
+	return u, err
+}
+
+func fromUnstructured(u *unstructured.Unstructured, obj runtime.Object) error {
+	tmp, err := json.Marshal(u)
+	if err != nil {
+		return err
+	}
+
+	codec := scheme.Codecs.LegacyCodec(schema.GroupVersion{Group: corev1.GroupName, Version: "v1"})
+	_, _, err = codec.Decode(tmp, nil, obj)
+	return err
+}
+
+func (d dynamicRig) doUnstructured(ctx context.Context, t *corev1.ConfigMap, doIt func(ctx context.Context, t *unstructured.Unstructured) (*unstructured.Unstructured, error)) (*corev1.ConfigMap, error) {
+	u, err := toUnstructured(t)
+	if err != nil {
+		return nil, err
+	}
+
+	uPtr, err := doIt(ctx, u)
+	if err != nil {
+		return nil, err
+	}
+
+	var res corev1.ConfigMap
+	err = fromUnstructured(uPtr, &res)
+	return &res, err
+}
+
+func (d dynamicRig) Create(ctx context.Context, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return d.doUnstructured(ctx, cm, func(ctx context.Context, u *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+		return d.client.Resource(d.gvr).Namespace(cm.Namespace).Create(ctx, u, metav1.CreateOptions{})
+	})
+}
+
+func (d dynamicRig) Update(ctx context.Context, cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return d.doUnstructured(ctx, cm, func(ctx context.Context, u *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+		return d.client.Resource(d.gvr).Namespace(cm.Namespace).Update(ctx, u, metav1.UpdateOptions{})
+	})
+}
+
+func (d dynamicRig) Delete(ctx context.Context, cm *corev1.ConfigMap) error {
+	return d.client.Resource(d.gvr).Namespace(cm.Namespace).Delete(ctx, cm.Name, metav1.DeleteOptions{})
 }
 
 func TestInformerFilters(t *testing.T) {

--- a/joined_collection.go
+++ b/joined_collection.go
@@ -1,0 +1,73 @@
+package krtlite
+
+type Joined[L, R any] struct {
+	Type  JoinType
+	Left  *L
+	Right *R
+	key   string
+}
+
+func (j Joined[L, R]) Key() string {
+	return j.key
+}
+
+// JoinType specifies different rules for handling nil entries in Join.
+type JoinType string
+
+const (
+	LeftJoin  JoinType = "left"
+	RightJoin JoinType = "right"
+	InnerJoin JoinType = "inner"
+)
+
+// Join is used to join two collections which share a key space. Items which share a key are combined into a single
+// Joined entry in the result.
+//
+// JoinType TODO: finish documenting
+func Join[L, R any](left Collection[L], right Collection[R], joinType JoinType, opts ...CollectionOption) Collection[Joined[L, R]] {
+	switch joinType {
+	case LeftJoin:
+		return Map(left, func(ktx Context, l L) *Joined[L, R] {
+			k := GetKey(l)
+			r := FetchOne(ktx, right, k)
+			return &Joined[L, R]{
+				key:   k,
+				Type:  LeftJoin,
+				Left:  &l,
+				Right: r,
+			}
+		}, opts...)
+
+	case RightJoin:
+		return Map(right, func(ktx Context, r R) *Joined[L, R] {
+			k := GetKey(r)
+			l := FetchOne(ktx, left, k)
+			return &Joined[L, R]{
+				key:   k,
+				Type:  RightJoin,
+				Left:  l,
+				Right: &r,
+			}
+		}, opts...)
+
+	case InnerJoin:
+		// At first glance, it seems that by implementing InnerJoin as a call to Map(left,...) we may miss some updates from
+		// the right collection. But the only updates we miss will be those who don't have a matching key in left, so this
+		// doesn't matter.
+		return Map(left, func(ktx Context, l L) *Joined[L, R] {
+			k := GetKey(l)
+			r := FetchOne(ktx, right, k)
+			if r == nil {
+				return nil
+			}
+			return &Joined[L, R]{
+				key:   k,
+				Type:  InnerJoin,
+				Left:  &l,
+				Right: r,
+			}
+		})
+	default:
+		panic("unsupported join type: " + joinType)
+	}
+}

--- a/merged_collection.go
+++ b/merged_collection.go
@@ -6,7 +6,7 @@ func MergeDisjoint[T any](cs []Collection[T], opts ...CollectionOption) Collecti
 	return newMergedCollection(cs, opts)
 }
 
-// MergeIndexableDisjoint is identical to MergeDisjoint, except it creates an IndexableCollection.
+// MergeIndexableDisjoint merges two IndexableCollections. The result is also Indexable.
 func MergeIndexableDisjoint[T any](cs []IndexableCollection[T], opts ...CollectionOption) IndexableCollection[T] {
 	castCs := make([]Collection[T], 0, len(cs))
 	for _, c := range cs {

--- a/shared_test.go
+++ b/shared_test.go
@@ -197,7 +197,6 @@ func (t *tracker[T]) Empty() {
 func (t *tracker[T]) Wait(events ...string) {
 	t.t.Helper()
 	assert.Eventually(t.t, func() bool {
-		slog.Info("events seen", "events", t.events)
 		t.mut.Lock()
 		defer t.mut.Unlock()
 		for _, ev := range events {

--- a/shared_test.go
+++ b/shared_test.go
@@ -197,6 +197,7 @@ func (t *tracker[T]) Empty() {
 func (t *tracker[T]) Wait(events ...string) {
 	t.t.Helper()
 	assert.Eventually(t.t, func() bool {
+		slog.Info("events seen", "events", t.events)
 		t.mut.Lock()
 		defer t.mut.Unlock()
 		for _, ev := range events {


### PR DESCRIPTION
Adds DynamicInformer, for use with dynamic clients, and `Join`, which combines two collections that share a key space.