### PR TITLE
Issues during sync

### DIFF
--- a/fetch.go
+++ b/fetch.go
@@ -404,6 +404,7 @@ func ExtractPodSelector(obj any) labels.Selector {
 
 	case *batchv1.Job:
 		lblSelector = typed.Spec.Selector
+
 	case *batchv1.CronJob:
 		lblSelector = typed.Spec.JobTemplate.Spec.Selector
 

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.35.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.5.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect

--- a/shared_test.go
+++ b/shared_test.go
@@ -204,7 +204,6 @@ func (t *tracker[T]) Wait(events ...string) {
 				return false
 			}
 		}
-
 		// consume events once all have been verified
 		for _, ev := range events {
 			delete(t.events, ev)


### PR DESCRIPTION
When sync takes a while, events can be dropped by registration handlers. Something in the sync logic is likely not waiting appropriately.