### PR TITLE
fix: use ctrlruntime Client correctly

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -41,7 +41,6 @@ func (c *krtClientWrapper) CreateService(ctx context.Context, svc *corev1.Servic
 
 func (c *krtClientWrapper) UpdatePod(ctx context.Context, pod *corev1.Pod) {
 	c.pods.Update(pod)
-	//pod.Status.PodIP = ip
 	c.pods.UpdateStatus(pod)
 }
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -141,7 +141,7 @@ func KrtLiteController(b *testing.B, events chan string) (Client, func()) {
 // NOTE: Results of this benchmark aren't valid -- the difference in the fake clients used by krt and krtlite creates
 // enough of a performance disparity to invalidate the benchmark.
 func BenchmarkController(b *testing.B) {
-	b.Skip("Benchmark results are invalid -- skipping")
+	b.Skip("Benchmark results are invalid -- skipping\nsee: https://github.com/kalexmills/krt-lite/issues/34")
 	oldLevel := slog.SetLogLoggerLevel(slog.LevelWarn)
 	defer slog.SetLogLoggerLevel(oldLevel)
 	watch.DefaultChanSize = 100_000

--- a/bench_test.go
+++ b/bench_test.go
@@ -41,6 +41,8 @@ func (c *krtClientWrapper) CreateService(ctx context.Context, svc *corev1.Servic
 
 func (c *krtClientWrapper) UpdatePod(ctx context.Context, pod *corev1.Pod) {
 	c.pods.Update(pod)
+	//pod.Status.PodIP = ip
+	c.pods.UpdateStatus(pod)
 }
 
 type ServiceWrapper struct{ *corev1.Service }
@@ -94,7 +96,10 @@ func (k *krtliteWrapper) CreateService(ctx context.Context, svc *corev1.Service)
 }
 
 func (k *krtliteWrapper) UpdatePod(ctx context.Context, pod *corev1.Pod) {
+	podIP := pod.Status.PodIP // save the PodIP so it isn't overwritten by Update
 	_ = k.client.Update(ctx, pod)
+	pod.Status.PodIP = podIP
+	_ = k.client.Status().Update(ctx, pod)
 }
 
 func KrtLiteController(b *testing.B, events chan string) (Client, func()) {
@@ -123,7 +128,7 @@ func KrtLiteController(b *testing.B, events chan string) (Client, func()) {
 			}
 		}
 		return result
-	}, krtlite.WithName("Workloads"), krtlite.WithSpuriousUpdates())
+	}, krtlite.WithName("Workloads"))
 
 	reg := Workloads.Register(func(e krtlite.Event[Workload]) {
 		events <- fmt.Sprintf("%s-%s", e.Latest().Name, e.Type)
@@ -134,7 +139,10 @@ func KrtLiteController(b *testing.B, events chan string) (Client, func()) {
 	}
 }
 
+// NOTE: Results of this benchmark aren't valid -- the difference in the fake clients used by krt and krtlite creates
+// enough of a performance disparity to invalidate the benchmark.
 func BenchmarkController(b *testing.B) {
+	b.Skip("Benchmark results are invalid -- skipping")
 	oldLevel := slog.SetLogLoggerLevel(slog.LevelWarn)
 	defer slog.SetLogLoggerLevel(oldLevel)
 	watch.DefaultChanSize = 100_000

--- a/derived_collection.go
+++ b/derived_collection.go
@@ -326,7 +326,7 @@ func (c *derivedCollection[I, O]) handleEvents(inputs []Event[I]) {
 
 				ev := Event[O]{}
 				if newOK && oldOK {
-					if !c.wantSpuriousUpdates && reflect.DeepEqual(newRes, oldRes) { // TODO: avoid reflection if possible
+					if !c.wantSpuriousUpdates && reflect.DeepEqual(newRes, oldRes) { // TODO: avoid reflection using Equaler
 						continue
 					}
 					ev.Type = EventUpdate

--- a/derived_collection_test.go
+++ b/derived_collection_test.go
@@ -488,3 +488,7 @@ func TestDerivedCollectionMultipleFetch(t *testing.T) {
 	require.NoError(t, err)
 	assertEventuallyLabelsEqual()
 }
+
+func TestDerivedCollectionSync(t *testing.T) {
+
+}

--- a/derived_collection_test.go
+++ b/derived_collection_test.go
@@ -488,7 +488,3 @@ func TestDerivedCollectionMultipleFetch(t *testing.T) {
 	require.NoError(t, err)
 	assertEventuallyLabelsEqual()
 }
-
-func TestDerivedCollectionSync(t *testing.T) {
-
-}

--- a/scale_test.go
+++ b/scale_test.go
@@ -107,7 +107,6 @@ func TestDetectDroppedEvents(t *testing.T) {
 
 	for _, s := range initialServices {
 		_ = c.Create(ctx, s)
-
 	}
 
 	var lastEventSeen time.Time
@@ -156,5 +155,5 @@ func TestDetectDroppedEvents(t *testing.T) {
 	}
 
 	assert.Equal(t, sentCount, count, "send and receive counts to not match")
-	assert.Len(t, events, 0, "no events should be outstanding")
+	assert.Len(t, events, 0, "no events should be outstanding") //nolint:testifylint // assert.Empty for channels yields poor error messages.
 }


### PR DESCRIPTION
Fixes incorrect usage of controller-runtime client -- whose fake mimics the status behavior of k8s clients. Resource status updates can only happen via an additional call.

This addresses one source of deadlocks for the benchmark and the scale test. Previously these were resolved by incorrectly (and spuriously) using WithSpuriousUpdates.

Relates to #34.